### PR TITLE
Feature: Compound property query

### DIFF
--- a/atoma-api/src/common/repositories/base.repository.ts
+++ b/atoma-api/src/common/repositories/base.repository.ts
@@ -1,9 +1,18 @@
 import { FindPaginatedInput } from '@common/pagination/pagination.input';
 import { Paginated } from '@common/pagination/pagination.types';
-import { Document, Model } from 'mongoose';
+import { Document, FilterQuery, Model, ProjectionType } from 'mongoose';
 
 export abstract class BaseRepository<T> {
   constructor(protected readonly _model: Model<T>) {}
+
+  /**
+   * model
+   *
+   * Getter for the internal _model property
+   */
+  model(): Model<T> {
+    return this._model;
+  }
 
   /**
    * findPaginated
@@ -53,8 +62,11 @@ export abstract class BaseRepository<T> {
    *
    * @returns {Promise<Document<T> | null>}
    */
-  async findOne(query: Record<string, unknown>): Promise<Document<T> | null> {
-    return this._model.findOne(query);
+  async findOne(
+    query: FilterQuery<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<Document<T> | null> {
+    return this._model.findOne(query, projection ?? null);
   }
 
   /**

--- a/atoma-api/src/modules/compounds/compounds.module.ts
+++ b/atoma-api/src/modules/compounds/compounds.module.ts
@@ -9,6 +9,7 @@ import { CompoundDataRepository } from './repositories/compound-data.repository'
 import { CompoundPropertiesRepository } from './repositories/compound-properties.repository';
 import { CompoundsResolver } from './resolvers/compounds.resolver';
 import { CompoundDataResolver } from './resolvers/compound-data.resolver';
+import { CompoundPropertiesResolver } from './resolvers/compound-properties.resolver';
 import {
   CompoundData,
   CompoundDataSchema,
@@ -35,9 +36,14 @@ import { PropertiesModule } from '@modules/properties/properties.module';
     CompoundsResolver,
     CompoundsService,
     CompoundsRepository,
+    CompoundPropertiesResolver,
     CompoundPropertiesService,
     CompoundPropertiesRepository,
   ],
-  exports: [CompoundsResolver, CompoundDataResolver],
+  exports: [
+    CompoundsResolver,
+    CompoundDataResolver,
+    CompoundPropertiesResolver,
+  ],
 })
 export class CompoundsModule {}

--- a/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
+++ b/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
@@ -1,0 +1,57 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+import { Logger } from '@nestjs/common';
+import { NotFoundError } from '@common/errors/not-found.error';
+import { CompoundProperty } from '@schemas/compound-property.schema';
+import { CompoundPropertiesService } from '../services/compound-properties.service';
+import { CompoundPropertyResult } from '../results/compound-property.result';
+
+@Resolver(() => CompoundProperty)
+export class CompoundPropertiesResolver {
+  private readonly _logger = new Logger(CompoundPropertiesResolver.name);
+
+  constructor(
+    private readonly _compoundPropertiesService: CompoundPropertiesService,
+  ) {}
+
+  /**
+   * findOneCompound
+   *
+   * Queries for a single compound, by name, for now.
+   *
+   * @param {string} compoundUuid
+   * @param {string} propertyUuid
+   * @returns {Promise<CompoundPropertyResult>}
+   */
+  @Query(() => CompoundPropertyResult, { name: 'compoundProperty' })
+  async findOneCompoundProperty(
+    @Args('compoundUuid', { type: () => String }) compoundUuid: string,
+    @Args('propertyUuid', { type: () => String }) propertyUuid: string,
+  ) {
+    this._logger.log({
+      message: 'Resolver `compoundProperty` called',
+      data: { compoundUuid },
+    });
+
+    const compoundProperty =
+      await this._compoundPropertiesService.findByCompoundAndPropertyUuid(
+        compoundUuid,
+        propertyUuid,
+      );
+
+    if (compoundProperty === null) {
+      this._logger.error({
+        message: 'No data for compound & property combination.',
+        data: { compoundUuid, propertyUuid },
+      });
+
+      return new NotFoundError(`Compound property not found.`);
+    }
+
+    this._logger.log({
+      message: 'Property found for specified compound.',
+      data: compoundProperty,
+    });
+
+    return CompoundProperty.from(compoundProperty);
+  }
+}

--- a/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
+++ b/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
@@ -4,12 +4,16 @@ import { NotFoundError } from '@common/errors/not-found.error';
 import { CompoundProperty } from '@schemas/compound-property.schema';
 import { CompoundPropertiesService } from '../services/compound-properties.service';
 import { CompoundPropertyResult } from '../results/compound-property.result';
+import { CompoundsService } from '../services/compounds.service';
+import { PropertiesService } from '@modules/properties/properties.service';
 
 @Resolver(() => CompoundProperty)
 export class CompoundPropertiesResolver {
   private readonly _logger = new Logger(CompoundPropertiesResolver.name);
 
   constructor(
+    private readonly _compoundsService: CompoundsService,
+    private readonly _propertiesService: PropertiesService,
     private readonly _compoundPropertiesService: CompoundPropertiesService,
   ) {}
 
@@ -29,13 +33,18 @@ export class CompoundPropertiesResolver {
   ) {
     this._logger.log({
       message: 'Resolver `compoundProperty` called',
-      data: { compoundUuid },
+      data: { compoundUuid, propertyUuid },
     });
 
+    const [compound, property] = await Promise.all([
+      this._compoundsService.findByUuid(compoundUuid),
+      this._propertiesService.findByUuid(propertyUuid),
+    ]);
+
     const compoundProperty =
-      await this._compoundPropertiesService.findByCompoundAndPropertyUuid(
-        compoundUuid,
-        propertyUuid,
+      await this._compoundPropertiesService.findByCompoundAndPropertyId(
+        compound?._id as any as string,
+        property?._id as any as string,
       );
 
     if (compoundProperty === null) {

--- a/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
+++ b/atoma-api/src/modules/compounds/resolvers/compound-properties.resolver.ts
@@ -4,16 +4,12 @@ import { NotFoundError } from '@common/errors/not-found.error';
 import { CompoundProperty } from '@schemas/compound-property.schema';
 import { CompoundPropertiesService } from '../services/compound-properties.service';
 import { CompoundPropertyResult } from '../results/compound-property.result';
-import { CompoundsService } from '../services/compounds.service';
-import { PropertiesService } from '@modules/properties/properties.service';
 
 @Resolver(() => CompoundProperty)
 export class CompoundPropertiesResolver {
   private readonly _logger = new Logger(CompoundPropertiesResolver.name);
 
   constructor(
-    private readonly _compoundsService: CompoundsService,
-    private readonly _propertiesService: PropertiesService,
     private readonly _compoundPropertiesService: CompoundPropertiesService,
   ) {}
 
@@ -36,18 +32,13 @@ export class CompoundPropertiesResolver {
       data: { compoundUuid, propertyUuid },
     });
 
-    const [compound, property] = await Promise.all([
-      this._compoundsService.findByUuid(compoundUuid),
-      this._propertiesService.findByUuid(propertyUuid),
-    ]);
-
     const compoundProperty =
-      await this._compoundPropertiesService.findByCompoundAndPropertyId(
-        compound?._id as any as string,
-        property?._id as any as string,
+      await this._compoundPropertiesService.findByCompoundAndPropertyUuid(
+        compoundUuid,
+        propertyUuid,
       );
 
-    if (compoundProperty === null) {
+    if (!compoundProperty) {
       this._logger.error({
         message: 'No data for compound & property combination.',
         data: { compoundUuid, propertyUuid },

--- a/atoma-api/src/modules/compounds/resolvers/compounds.resolver.ts
+++ b/atoma-api/src/modules/compounds/resolvers/compounds.resolver.ts
@@ -1,4 +1,11 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import {
+  Args,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
 import { Document } from 'mongoose';
 import { Compound, PaginatedCompounds } from '@schemas/compound.schema';
 import { CompoundsService } from '../services/compounds.service';

--- a/atoma-api/src/modules/compounds/resolvers/compounds.resolver.ts
+++ b/atoma-api/src/modules/compounds/resolvers/compounds.resolver.ts
@@ -29,7 +29,7 @@ export class CompoundsResolver {
    *
    * @returns {Promise<PaginatedCompounds>}
    */
-  @Query(() => PaginatedCompounds)
+  @Query(() => PaginatedCompounds, { name: 'compounds' })
   async findManyCompounds(
     @Args('options') options: FindPaginatedInput,
   ): Promise<PaginatedCompounds> {
@@ -53,7 +53,7 @@ export class CompoundsResolver {
    * @param {string} name
    * @returns {Promise<FindCompoundResult>}
    */
-  @Query(() => FindCompoundResult)
+  @Query(() => FindCompoundResult, { name: 'compound' })
   async findOneCompound(@Args('name', { type: () => String }) name: string) {
     this._logger.log({
       message: 'Resolver `findOneCompound` called',

--- a/atoma-api/src/modules/compounds/results/compound-property.result.ts
+++ b/atoma-api/src/modules/compounds/results/compound-property.result.ts
@@ -1,0 +1,8 @@
+import { NotFoundError } from '@common/errors/not-found.error';
+import { createUnionType } from '@nestjs/graphql';
+import { CompoundProperty } from '@schemas/compound-property.schema';
+
+export const CompoundPropertyResult = createUnionType({
+  name: 'CompoundPropertyResult',
+  types: () => [CompoundProperty, NotFoundError] as const,
+});

--- a/atoma-api/src/modules/compounds/services/compound-properties.service.ts
+++ b/atoma-api/src/modules/compounds/services/compound-properties.service.ts
@@ -59,20 +59,19 @@ export class CompoundPropertiesService {
   }
 
   /**
-   * findByCompoundAndPropertyUuid
+   * findByCompoundAndPropertyId
    *
    * Finds one `compound-property` by providing both a compound and a
-   * property's uuids.
+   * property's ids.
    *
-   * @param {string} compoundUuid
-   * @param {string} propertyUuid
+   * @param {string} compoundId
+   * @param {string} propertyId
    * @returns {Promise<CompoundProperty>}
    */
-  async findByCompoundAndPropertyUuid(
+  async findByCompoundAndPropertyId(
     compoundId: string,
     propertyId: string,
   ): Promise<Document<CompoundProperty>> {
-    // TODO: Usar uuids
     return this._compoundPropertiesRepository.findOne({
       compoundId,
       propertyId,

--- a/atoma-api/src/modules/compounds/services/compound-properties.service.ts
+++ b/atoma-api/src/modules/compounds/services/compound-properties.service.ts
@@ -45,8 +45,8 @@ export class CompoundPropertiesService {
 
     const newCompoundProperty = await this._compoundPropertiesRepository.create(
       {
-        compoundId,
-        propertyId,
+        compound: compoundId,
+        property: propertyId,
       },
     );
 
@@ -64,17 +64,48 @@ export class CompoundPropertiesService {
    * Finds one `compound-property` by providing both a compound and a
    * property's ids.
    *
-   * @param {string} compoundId
-   * @param {string} propertyId
+   * @param {string} compoundUuid
+   * @param {string} propertyUuid
    * @returns {Promise<CompoundProperty>}
    */
-  async findByCompoundAndPropertyId(
-    compoundId: string,
-    propertyId: string,
+  async findByCompoundAndPropertyUuid(
+    compoundUuid: string,
+    propertyUuid: string,
   ): Promise<Document<CompoundProperty>> {
-    return this._compoundPropertiesRepository.findOne({
-      compoundId,
-      propertyId,
-    });
+    const result = await this._compoundPropertiesRepository
+      .model()
+      .aggregate([
+        {
+          $lookup: {
+            from: 'compounds',
+            localField: 'compound',
+            foreignField: '_id',
+            as: 'compound',
+          },
+        },
+        {
+          $lookup: {
+            from: 'properties',
+            localField: 'property',
+            foreignField: '_id',
+            as: 'property',
+          },
+        },
+        {
+          $addFields: {
+            compound: { $arrayElemAt: ['$compound', 0] },
+            property: { $arrayElemAt: ['$property', 0] },
+          },
+        },
+        {
+          $match: {
+            'compound.uuid': compoundUuid,
+            'property.uuid': propertyUuid,
+          },
+        },
+      ])
+      .exec();
+
+    return result[0];
   }
 }

--- a/atoma-api/src/modules/compounds/services/compound-properties.service.ts
+++ b/atoma-api/src/modules/compounds/services/compound-properties.service.ts
@@ -57,4 +57,25 @@ export class CompoundPropertiesService {
 
     return newCompoundProperty;
   }
+
+  /**
+   * findByCompoundAndPropertyUuid
+   *
+   * Finds one `compound-property` by providing both a compound and a
+   * property's uuids.
+   *
+   * @param {string} compoundUuid
+   * @param {string} propertyUuid
+   * @returns {Promise<CompoundProperty>}
+   */
+  async findByCompoundAndPropertyUuid(
+    compoundId: string,
+    propertyId: string,
+  ): Promise<Document<CompoundProperty>> {
+    // TODO: Usar uuids
+    return this._compoundPropertiesRepository.findOne({
+      compoundId,
+      propertyId,
+    });
+  }
 }

--- a/atoma-api/src/modules/properties/properties.resolver.ts
+++ b/atoma-api/src/modules/properties/properties.resolver.ts
@@ -17,7 +17,7 @@ export class PropertiesResolver {
    *
    * @returns {Promise<PaginatedProperties>}
    */
-  @Query(() => PaginatedProperties)
+  @Query(() => PaginatedProperties, { name: 'properties' })
   async findManyProperties(
     @Args('options') options: FindPaginatedInput,
   ): Promise<PaginatedProperties> {

--- a/atoma-api/src/schema.gql
+++ b/atoma-api/src/schema.gql
@@ -13,8 +13,12 @@ type CompoundData {
 }
 
 type CompoundProperty {
+  compound: Compound!
+  property: Property!
   uuid: String!
 }
+
+union CompoundPropertyResult = CompoundProperty | NotFoundError
 
 input ConditionInput {
   value: Float!
@@ -75,6 +79,7 @@ type Property {
 }
 
 type Query {
+  compoundProperty(compoundUuid: String!, propertyUuid: String!): CompoundPropertyResult!
   findManyCompounds(options: FindPaginatedInput!): PaginatedCompounds!
   findManyProperties(options: FindPaginatedInput!): PaginatedProperties!
   findOneCompound(name: String!): FindCompoundResult!

--- a/atoma-api/src/schema.gql
+++ b/atoma-api/src/schema.gql
@@ -79,8 +79,8 @@ type Property {
 }
 
 type Query {
+  compound(name: String!): FindCompoundResult!
   compoundProperty(compoundUuid: String!, propertyUuid: String!): CompoundPropertyResult!
-  findManyCompounds(options: FindPaginatedInput!): PaginatedCompounds!
-  findManyProperties(options: FindPaginatedInput!): PaginatedProperties!
-  findOneCompound(name: String!): FindCompoundResult!
+  compounds(options: FindPaginatedInput!): PaginatedCompounds!
+  properties(options: FindPaginatedInput!): PaginatedProperties!
 }

--- a/atoma-api/src/schemas/compound-data.schema.ts
+++ b/atoma-api/src/schemas/compound-data.schema.ts
@@ -15,7 +15,7 @@ export class CompoundData extends BaseEntity {
   }
 
   @Prop({ type: Sch.Types.ObjectId, ref: CompoundProperty.name })
-  compoundPropertyId: CompoundProperty;
+  compoundProperty: CompoundProperty;
 
   @Prop({ type: [{ type: ConditionSchema }] })
   conditions: Condition[];

--- a/atoma-api/src/schemas/compound-property.schema.ts
+++ b/atoma-api/src/schemas/compound-property.schema.ts
@@ -1,6 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import { Paginated } from '@common/pagination/paginated.schema';
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Schema as Sch } from 'mongoose';
 import { BaseEntity } from '@common/repositories/base.schema';
@@ -16,6 +16,7 @@ export class CompoundProperty extends BaseEntity {
     return plainToInstance(CompoundProperty, object.toObject());
   }
 
+  @Prop(() => Sch.Types.ObjectId)
   _id: string;
 
   @Prop({ type: Sch.Types.ObjectId, ref: Compound.name })
@@ -23,6 +24,12 @@ export class CompoundProperty extends BaseEntity {
 
   @Prop({ type: Sch.Types.ObjectId, ref: Property.name })
   propertyId: Property;
+
+  @Field(() => Compound)
+  compound: Compound;
+
+  @Field(() => Property)
+  property: Property;
 }
 
 @ObjectType()

--- a/atoma-api/src/schemas/compound-property.schema.ts
+++ b/atoma-api/src/schemas/compound-property.schema.ts
@@ -13,21 +13,14 @@ import { Property } from './property.schema';
 })
 export class CompoundProperty extends BaseEntity {
   static from(object: Document<CompoundProperty>): CompoundProperty {
-    return plainToInstance(CompoundProperty, object.toObject());
+    return plainToInstance(CompoundProperty, object);
   }
 
-  @Prop(() => Sch.Types.ObjectId)
-  _id: string;
-
   @Prop({ type: Sch.Types.ObjectId, ref: Compound.name })
-  compoundId: Compound;
-
-  @Prop({ type: Sch.Types.ObjectId, ref: Property.name })
-  propertyId: Property;
-
   @Field(() => Compound)
   compound: Compound;
 
+  @Prop({ type: Sch.Types.ObjectId, ref: Property.name })
   @Field(() => Property)
   property: Property;
 }

--- a/atoma-api/src/schemas/compound.schema.ts
+++ b/atoma-api/src/schemas/compound.schema.ts
@@ -2,8 +2,9 @@ import { plainToInstance } from 'class-transformer';
 import { Paginated } from '@common/pagination/paginated.schema';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Schema as Sch } from 'mongoose';
 import { BaseEntity } from '@common/repositories/base.schema';
+import { Property } from './property.schema';
 
 @ObjectType()
 @Schema()
@@ -12,8 +13,8 @@ export class Compound extends BaseEntity {
     return plainToInstance(Compound, object.toObject());
   }
 
-  @Prop()
-  id: number;
+  @Prop(() => Sch.Types.ObjectId)
+  _id: string;
 
   @Field(() => String)
   @Prop({ unique: true })

--- a/atoma-api/src/schemas/compound.schema.ts
+++ b/atoma-api/src/schemas/compound.schema.ts
@@ -2,9 +2,8 @@ import { plainToInstance } from 'class-transformer';
 import { Paginated } from '@common/pagination/paginated.schema';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as Sch } from 'mongoose';
+import { Document } from 'mongoose';
 import { BaseEntity } from '@common/repositories/base.schema';
-import { Property } from './property.schema';
 
 @ObjectType()
 @Schema()
@@ -12,9 +11,6 @@ export class Compound extends BaseEntity {
   static from(object: Document<Compound>): Compound {
     return plainToInstance(Compound, object.toObject());
   }
-
-  @Prop(() => Sch.Types.ObjectId)
-  _id: string;
 
   @Field(() => String)
   @Prop({ unique: true })


### PR DESCRIPTION
Adds the ability to query compound properties by compound uuid and property uuid. Later on, we should be able to populate data for a set of conditions. The full query might look something like this:

```graphql
{
   compoundProperty(
    compoundUuid: "c038513c-8a0c-47c7-90e2-a9a27d8a1200",
    propertyUuid: "45669bca-204e-4a91-9804-714c0ca1612c"
  ) {
    __typename
    
    ...on NotFoundError {
      code
      message
    }
    
    ...on CompoundProperty {
    	uuid
        value(conditions: {
           temperature: 300,
        })
    }
  }
}
```