### PR TITLE
Refactor: Compound property DB remodeling

### DIFF
--- a/atoma-api/src/modules/compounds/repositories/compound-data.repository.ts
+++ b/atoma-api/src/modules/compounds/repositories/compound-data.repository.ts
@@ -2,10 +2,43 @@ import { BaseRepository } from '@modules/neo4j/utils/base.repository';
 import { Neo4jService } from '@modules/neo4j/neo4j.service';
 import { Injectable } from '@nestjs/common';
 import { CompoundData } from '@schemas/compound-data.schema';
+import { CreateCompoundDataInput } from '../inputs/create-compount-data.input';
+import { plainToInstance } from 'class-transformer';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class CompoundDataRepository extends BaseRepository<CompoundData> {
   constructor(protected readonly _neo4jService: Neo4jService) {
     super(CompoundData, _neo4jService);
+  }
+
+  /**
+   * _createConnected
+   *
+   * Creates a `CompoundData` node connected to a `CompoundProperty` record.`
+   */
+  async createConnected(
+    compoundPropertyUuid: string,
+    payload: CreateCompoundDataInput,
+  ): Promise<CompoundData> {
+    const uuid = uuidv4();
+
+    const { records } = await this._neo4jService.write(
+      `
+      MATCH
+        (compoundProperty:CompoundProperty {uuid: $compoundPropertyUuid})
+      CREATE
+        (compoundProperty)
+        -[:HAS_DATA]->
+        (compoundData:CompoundData {value: $value, uuid: $uuid})
+      RETURN compoundData
+      `,
+      { ...payload, uuid, compoundPropertyUuid },
+    );
+
+    return plainToInstance(
+      CompoundData,
+      records[0].get('compoundData').properties,
+    );
   }
 }

--- a/atoma-api/src/modules/compounds/services/compound-data.service.ts
+++ b/atoma-api/src/modules/compounds/services/compound-data.service.ts
@@ -59,21 +59,21 @@ export class CompoundDataService {
       data: payload,
     });
 
-    const connectionUuid =
-      await this._compoundPropertiesService.idempotentCreateConnection(
+    const compoundPropertyUuid =
+      await this._compoundPropertiesService.idempotentCreateCompoundProperty(
         compoundUuid,
         propertyUuid,
       );
 
     this._logger.log({
-      message: 'Creating compound property data record in database...',
+      message: 'Creating compound data record in database...',
       data: payload,
     });
 
-    const compoundData = await this._compoundDataRepository.createNode({
-      uuid: connectionUuid,
-      // ...payload,
-    });
+    const compoundData = await this._compoundDataRepository.createConnected(
+      compoundPropertyUuid,
+      payload,
+    );
 
     this._logger.log({
       message: 'Compound property data successfully created.',
@@ -82,6 +82,8 @@ export class CompoundDataService {
 
     return compoundData;
   }
+
+  /**
 
   /**
    * _findCompoundAndProperty


### PR DESCRIPTION
Reboots the compound property relation. Now, a node `CompoundProperty` points to a `Compound` with a `BELONGS_TO` relation, and to a `Property` node with a `IS_PROPERTY` relation.